### PR TITLE
Implemented app.UseKissLogMiddleware(options) overload

### DIFF
--- a/src/KissLog.AspNetCore/IOptionsBuilder.cs
+++ b/src/KissLog.AspNetCore/IOptionsBuilder.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace KissLog.AspNetCore
+{
+    public interface IOptionsBuilder
+    {
+        List<ILogListener> Listeners { get; }
+        Options Options { get; }
+    }
+}

--- a/src/KissLog.AspNetCore/KissLog.AspNetCore.csproj
+++ b/src/KissLog.AspNetCore/KissLog.AspNetCore.csproj
@@ -12,10 +12,10 @@ Install this package on ASP.NET Core web applications.</Description>
     <PackageIconUrl>https://kisslog.net/cdn/KissLog/logos/32.png</PackageIconUrl>
     <PackageTags>KissLog, AspNetCore, NetCore, Core</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.2.0</Version>
-    <AssemblyVersion>2.2.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
-    <PackageReleaseNotes>Adapted to KissLog 3.2.0 improvements</PackageReleaseNotes>
+    <Version>2.2.1</Version>
+    <AssemblyVersion>2.2.1.0</AssemblyVersion>
+    <FileVersion>2.2.1.0</FileVersion>
+    <PackageReleaseNotes>Implemented app.UseKissLogMiddleware(options) overload.</PackageReleaseNotes>
     <PackageId>KissLog.AspNetCore</PackageId>
     <RepositoryUrl>https://github.com/KissLog-net/KissLog.Sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/KissLog.AspNetCore/KissLogMiddleware.cs
+++ b/src/KissLog.AspNetCore/KissLogMiddleware.cs
@@ -1,6 +1,5 @@
 ﻿using KissLog.Internal;
 using KissLog.Web;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
@@ -128,19 +127,6 @@ namespace KissLog.AspNetCore
             }
 
             return true;
-        }
-    }
-
-    public static class KissLogMiddlewareExtensions
-    {
-        static KissLogMiddlewareExtensions()
-        {
-            PackageInit.Init();
-        }
-
-        public static IApplicationBuilder UseKissLogMiddleware(this IApplicationBuilder builder)
-        {
-            return builder.UseMiddleware<KissLogMiddleware>();
         }
     }
 }

--- a/src/KissLog.AspNetCore/KissLogMiddlewareExtensions.cs
+++ b/src/KissLog.AspNetCore/KissLogMiddlewareExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using System;
+
+namespace KissLog.AspNetCore
+{
+    public static class KissLogMiddlewareExtensions
+    {
+        static KissLogMiddlewareExtensions()
+        {
+            PackageInit.Init();
+        }
+
+        public static IApplicationBuilder UseKissLogMiddleware(this IApplicationBuilder builder)
+        {
+            return builder.UseKissLogMiddleware(options => { });
+        }
+
+        public static IApplicationBuilder UseKissLogMiddleware(this IApplicationBuilder builder, Action<IOptionsBuilder> configureOptions)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            configureOptions?.Invoke(new OptionsBuilder());
+
+            return builder.UseMiddleware<KissLogMiddleware>();
+        }
+    }
+}

--- a/src/KissLog.AspNetCore/OptionsBuilder.cs
+++ b/src/KissLog.AspNetCore/OptionsBuilder.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace KissLog.AspNetCore
+{
+    internal class OptionsBuilder : IOptionsBuilder
+    {
+        public List<ILogListener> Listeners => KissLogConfiguration.Listeners;
+        public Options Options => KissLogConfiguration.Options;
+    }
+}


### PR DESCRIPTION
Usage:

```csharp
app.UseKissLogMiddleware(options =>
{
    options.Options.ShouldLogResponseBody((listener, args, defaultValue) => {
        return args.WebRequestProperties.Response.HttpStatusCode >= HttpStatusCode.BadRequest;
    });

    options.Listeners.Add(new KissLogApiListener(new KissLog.Apis.v1.Auth.Application(
        Configuration["KissLog:OrganizationId"],
        Configuration["KissLog:ApplicationId"]))
    );
});
```